### PR TITLE
Update hero component pricing text

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -68,7 +68,7 @@ import HeroIlust from "../../assets/pics/hero.svg";
                 Free 14-day trial
               </span>
               <span>•</span>
-              <span>No credit card required</span>
+              <span>Starting at $19 USD/month</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Replace "No credit card required" text in the hero component with "Starting at $19 USD/month" to display pricing information.