### PR TITLE
Remove pb-20 class from Hero section

### DIFF
--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -5,7 +5,7 @@ import Section from "./Section.astro";
 import HeroIlust from "../../assets/pics/hero.svg";
 ---
 
-<Section id="home" className="pt-10 pb-20">
+<Section id="home" className="pt-10">
   <div
     class="relative flex flex-col-reverse items-center md:flex-row"
     id="hero"


### PR DESCRIPTION
Remove `pb-20` CSS class from Hero.astro to remove padding-bottom styling.