### PR TITLE
Create terms and privacy policy pages

### DIFF
--- a/src/components/ui/Footer.astro
+++ b/src/components/ui/Footer.astro
@@ -89,6 +89,10 @@ const links = [
             class="underline">sturmfrei</a
           > product</span
         >
+        <div class="mt-2 flex flex-col gap-2 lg:mt-0 lg:flex-row lg:gap-4">
+          <a href="/terms" class="underline">Terms of Service</a>
+          <a href="/privacy" class="underline">Privacy Policy</a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,137 @@
+---
+import MainLayout from "../layouts/MainLayout.astro";
+---
+
+<MainLayout title="Privacy Policy">
+  <main class="space-y-20">
+    <div class="mx-auto max-w-4xl px-4 py-8 lg:px-3 lg:py-16">
+      <div class="prose prose-lg max-w-none">
+        <h1 class="text-4xl font-bold mb-8">Privacy Policy</h1>
+        
+        <p class="text-gray-600 mb-8">Last updated: January 2025</p>
+        
+        <h2 class="text-2xl font-semibold mt-8 mb-4">1. Introduction</h2>
+        <p>
+          Sturmfrei Pty Ltd ("Company", "we", "us", or "our") operates the EasyEdit Shopify application ("Service"). This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Service.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">2. Information We Collect</h2>
+        
+        <h3 class="text-xl font-semibold mt-6 mb-3">2.1 Information from Shopify</h3>
+        <p>
+          When you install EasyEdit on your Shopify store, we collect:
+        </p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>Store information (store name, domain, contact details)</li>
+          <li>Order data necessary for the order editing functionality</li>
+          <li>Customer information related to orders being edited</li>
+          <li>Product information for order modification features</li>
+        </ul>
+
+        <h3 class="text-xl font-semibold mt-6 mb-3">2.2 Usage Information</h3>
+        <p>
+          We automatically collect information about how you use the Service:
+        </p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>Application usage analytics</li>
+          <li>Feature utilization data</li>
+          <li>Error logs and performance metrics</li>
+          <li>IP addresses and browser information</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">3. How We Use Your Information</h2>
+        <p>
+          We use the collected information to:
+        </p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>Provide and maintain the EasyEdit service</li>
+          <li>Enable order editing functionality for your customers</li>
+          <li>Improve and optimize our service</li>
+          <li>Provide customer support</li>
+          <li>Detect and prevent fraud or abuse</li>
+          <li>Comply with legal obligations</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">4. Information Sharing</h2>
+        
+        <h3 class="text-xl font-semibold mt-6 mb-3">4.1 With Shopify</h3>
+        <p>
+          As a Shopify application, we operate within Shopify's ecosystem and share information with Shopify as necessary to provide the Service in accordance with Shopify's Partner Program Agreement.
+        </p>
+
+        <h3 class="text-xl font-semibold mt-6 mb-3">4.2 Service Providers</h3>
+        <p>
+          We may share information with third-party service providers who assist us in operating the Service, such as hosting providers and analytics services.
+        </p>
+
+        <h3 class="text-xl font-semibold mt-6 mb-3">4.3 Legal Requirements</h3>
+        <p>
+          We may disclose information if required by law or in response to valid requests by public authorities.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">5. Data Security</h2>
+        <p>
+          We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the Internet is 100% secure.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">6. Data Retention</h2>
+        <p>
+          We retain your information only for as long as necessary to provide the Service and fulfill the purposes outlined in this Privacy Policy, unless a longer retention period is required by law.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">7. Your Rights</h2>
+        <p>
+          Depending on your location, you may have the following rights regarding your personal information:
+        </p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>Right to access your personal information</li>
+          <li>Right to correct inaccurate information</li>
+          <li>Right to delete your personal information</li>
+          <li>Right to restrict processing</li>
+          <li>Right to data portability</li>
+          <li>Right to object to processing</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">8. International Data Transfers</h2>
+        <p>
+          Your information may be transferred to and processed in countries other than your own. We ensure that such transfers comply with applicable data protection laws through appropriate safeguards.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">9. Children's Privacy</h2>
+        <p>
+          Our Service is not intended for use by children under the age of 13. We do not knowingly collect personal information from children under 13.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">10. Cookies and Tracking</h2>
+        <p>
+          We use cookies and similar technologies to enhance your experience with our Service. You can control cookie settings through your browser preferences.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">11. Third-Party Links</h2>
+        <p>
+          Our Service may contain links to third-party websites. We are not responsible for the privacy practices of these external sites.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">12. Changes to This Privacy Policy</h2>
+        <p>
+          We may update this Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page and updating the "Last updated" date.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">13. Contact Us</h2>
+        <p>
+          If you have any questions about this Privacy Policy, please contact us:
+        </p>
+        <address class="not-italic">
+          Sturmfrei Pty Ltd<br>
+          Email: support@geteasyedit.com<br>
+          Website: <a href="https://sturmfrei.com.au" class="text-blue-600 underline">https://sturmfrei.com.au</a>
+        </address>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">14. Shopify App Store</h2>
+        <p>
+          For questions about how Shopify handles your data, please refer to <a href="https://www.shopify.com/legal/privacy" class="text-blue-600 underline">Shopify's Privacy Policy</a>.
+        </p>
+      </div>
+    </div>
+  </main>
+</MainLayout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -1,0 +1,97 @@
+---
+import MainLayout from "../layouts/MainLayout.astro";
+---
+
+<MainLayout title="Terms of Service">
+  <main class="space-y-20">
+    <div class="mx-auto max-w-4xl px-4 py-8 lg:px-3 lg:py-16">
+      <div class="prose prose-lg max-w-none">
+        <h1 class="text-4xl font-bold mb-8">Terms of Service</h1>
+        
+        <p class="text-gray-600 mb-8">Last updated: January 2025</p>
+        
+        <h2 class="text-2xl font-semibold mt-8 mb-4">1. Acceptance of Terms</h2>
+        <p>
+          By accessing and using EasyEdit ("the Service"), a Shopify application developed by Sturmfrei Pty Ltd ("Company", "we", "us", or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms, please do not use the Service.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">2. Description of Service</h2>
+        <p>
+          EasyEdit is a Shopify application that enables e-commerce store customers to edit their own orders, including modifications, shipping updates, product swapping, and cancellations. The Service is provided through the Shopify App Store and integrates with Shopify stores.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">3. Eligibility</h2>
+        <p>
+          You must be at least 18 years old and have the legal authority to enter into these Terms. By using the Service, you represent and warrant that you meet these eligibility requirements.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">4. Shopify App Store</h2>
+        <p>
+          The Service is distributed through the Shopify App Store. Your use of the Service is subject to both these Terms and Shopify's Terms of Service. In case of conflict between these Terms and Shopify's Terms of Service, Shopify's Terms of Service shall prevail.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">5. Subscription and Billing</h2>
+        <p>
+          The Service is offered on a subscription basis with different pricing tiers. All billing is handled through Shopify's billing system. Subscription fees are non-refundable except as required by law or as specifically stated in these Terms.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">6. Data and Privacy</h2>
+        <p>
+          We collect and process data in accordance with our Privacy Policy. By using the Service, you consent to the collection and use of your information as described in our Privacy Policy.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">7. Prohibited Use</h2>
+        <p>
+          You agree not to:
+        </p>
+        <ul class="list-disc pl-6 mb-4">
+          <li>Use the Service for any illegal or unauthorized purpose</li>
+          <li>Violate any laws or regulations</li>
+          <li>Infringe upon the rights of others</li>
+          <li>Transmit malicious code or conduct security attacks</li>
+          <li>Attempt to reverse engineer or modify the Service</li>
+        </ul>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">8. Intellectual Property</h2>
+        <p>
+          The Service and all related content, features, and functionality are owned by Sturmfrei Pty Ltd and are protected by intellectual property laws. You are granted a limited, non-exclusive license to use the Service in accordance with these Terms.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">9. Limitation of Liability</h2>
+        <p>
+          To the maximum extent permitted by law, Sturmfrei Pty Ltd shall not be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to loss of profits, data, or other intangible losses.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">10. Disclaimer of Warranties</h2>
+        <p>
+          The Service is provided "as is" without warranties of any kind, either express or implied. We do not warrant that the Service will be uninterrupted, secure, or error-free.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">11. Termination</h2>
+        <p>
+          You may terminate your use of the Service at any time by uninstalling the application from your Shopify store. We may terminate or suspend your access to the Service immediately if you breach these Terms.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">12. Governing Law</h2>
+        <p>
+          These Terms are governed by and construed in accordance with the laws of New South Wales, Australia. Any disputes arising from these Terms shall be subject to the exclusive jurisdiction of the courts of New South Wales.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">13. Changes to Terms</h2>
+        <p>
+          We reserve the right to modify these Terms at any time. We will notify users of any material changes by posting the updated Terms on our website. Your continued use of the Service after such changes constitutes acceptance of the new Terms.
+        </p>
+
+        <h2 class="text-2xl font-semibold mt-8 mb-4">14. Contact Information</h2>
+        <p>
+          If you have any questions about these Terms, please contact us at:
+        </p>
+        <address class="not-italic">
+          Sturmfrei Pty Ltd<br>
+          Email: support@geteasyedit.com<br>
+          Website: <a href="https://sturmfrei.com.au" class="text-blue-600 underline">https://sturmfrei.com.au</a>
+        </address>
+      </div>
+    </div>
+  </main>
+</MainLayout>


### PR DESCRIPTION
Add Terms of Service and Privacy Policy pages and link them in the footer to meet legal requirements for a Shopify SaaS business.