### PR TITLE
Update about link in Footer.astro

### DIFF
--- a/src/components/ui/Footer.astro
+++ b/src/components/ui/Footer.astro
@@ -14,7 +14,7 @@ const logos = [
 ];
 
 const links = [
-  { name: "About us", href: "/#about" },
+  { name: "About", href: "/about" },
   { name: "Features", href: "/#features" },
   { name: "Pricing", href: "/#plans" },
 ];


### PR DESCRIPTION
Remove 'us' from 'About us' link and '#' from its href in Footer.astro.